### PR TITLE
Fix crash issue on some special Windows machines.

### DIFF
--- a/internal/win/ole32.go
+++ b/internal/win/ole32.go
@@ -24,6 +24,7 @@ const (
 
 	E_CANCELED         = windows.ERROR_CANCELLED | windows.FACILITY_WIN32<<16 | 0x80000000
 	RPC_E_CHANGED_MODE = syscall.Errno(windows.RPC_E_CHANGED_MODE)
+	S_FALSE            = syscall.Errno(windows.S_FALSE)
 )
 
 func CoInitializeEx(reserved uintptr, coInit uint32) error {


### PR DESCRIPTION
The program crashed on Windows when selecting files for the second time, with the same behavior as 
https://stackoverflow.com/questions/35366998/2nd-call-to-getopenfilename-crashes-without-error-on-win-8-1-64-bit-machine

The original issue: https://github.com/trzsz/trzsz-ssh/issues/76