### PR TITLE
Add AlwaysOnTop option for message dialogs on windows

### DIFF
--- a/internal/win/user32.go
+++ b/internal/win/user32.go
@@ -37,6 +37,7 @@ const (
 	MB_DEFBUTTON1        = windows.MB_DEFBUTTON1
 	MB_DEFBUTTON2        = windows.MB_DEFBUTTON2
 	MB_DEFBUTTON3        = windows.MB_DEFBUTTON3
+	MB_SYSTEMMODAL       = windows.MB_SYSTEMMODAL
 
 	// Window messages
 	WM_DESTROY     = 0x0002

--- a/msg_windows.go
+++ b/msg_windows.go
@@ -52,6 +52,10 @@ func message(kind messageKind, text string, opts options) error {
 		}
 	}
 
+	if opts.alwaysOnTop {
+		flags |= win.MB_SYSTEMMODAL
+	}
+
 	owner, _ := opts.attach.(win.HWND)
 	defer setup(owner)()
 	unhook, err := hookMessageDialog(opts)

--- a/zenity.go
+++ b/zenity.go
@@ -49,6 +49,7 @@ type options struct {
 	windowIcon    any
 	attach        any
 	modal         bool
+	alwaysOnTop   bool
 	display       string
 	class         string
 	name          string
@@ -113,6 +114,13 @@ func applyOptions(options []Option) (res options) {
 // Title returns an Option to set the dialog title.
 func Title(title string) Option {
 	return funcOption(func(o *options) { o.title = &title })
+}
+
+// AlwaysOnTop returns an Option to set the dialog to be always on top (Windows only)..
+func AlwaysOnTop(alwaysOnTop bool) Option {
+	return funcOption(func(o *options) {
+		o.alwaysOnTop = alwaysOnTop
+	})
 }
 
 // Width returns an Option to set the dialog width (Unix only).


### PR DESCRIPTION

Zenity dialog without `AlwaysOnTop(true)`
![image](https://github.com/ncruces/zenity/assets/30137826/754d99ec-1e74-4a70-959f-5d2442150a4c)

Zenity dialog with `AlwaysOnTop(true)`
![image](https://github.com/ncruces/zenity/assets/30137826/0e08790f-7383-4e08-ac3c-22c73caf9e8e)
