### PR TITLE
Allow initial selection of items in multi-select list on linux

### DIFF
--- a/list_unix.go
+++ b/list_unix.go
@@ -27,16 +27,28 @@ func list(text string, items []string, opts options) (string, error) {
 	return strResult(opts, out, err)
 }
 
+func isSelected(defaults []string, value string) string {
+	for _, d := range defaults {
+		if d == value {
+			return "TRUE"
+		}
+	}
+	return "FALSE"
+}
+
 func listMultiple(text string, items []string, opts options) ([]string, error) {
 	args := []string{"--list", "--hide-header", "--text", text, "--multiple", "--separator", zenutil.Separator}
 	args = appendGeneral(args, opts)
 	args = appendButtons(args, opts)
 	args = appendWidthHeight(args, opts)
 	args = appendWindowIcon(args, opts)
-	if opts.listKind == checkListKind {
+
+	// Having multiple items selected by default is only supported for checklists.
+	// In case user provides non-empty list of default items, checklist will be enforced to avoid confusion.
+	if opts.listKind == checkListKind || len(opts.defaultItems) > 0 {
 		args = append(args, "--checklist", "--column=", "--column=")
 		for _, i := range items {
-			args = append(args, "", i)
+			args = append(args, isSelected(opts.defaultItems, i), i)
 		}
 	} else {
 		args = append(args, "--column=")


### PR DESCRIPTION
I've noticed that `zenity.DefaultItems()` only works for Mac and Windows (doc) when using a multiple-select list.
I'm adding the same functionality of having pre-selected items after passing the `zenity.DefaultItems()` to the Linux code as well.

Zenity requires passing the "TRUE/FALSE" word as a separate argument to enable selection. The function `isSelected` encapsulates this behavior.

This may be a controversial decision, but I enforce the "checklist" style whenever the `zenity.DefaultItems()` is passed. Without the checklist stile, the functionality will not work (as Zenity doesn't allow pre-selection for standard lists). As far as I like flexibility, I find it confusing when list stile enables or disables certain (crucial) functionality - therefore, I treat it as a lesser evil. 